### PR TITLE
fix: libuv pipeline buffer issue

### DIFF
--- a/src/config/config_types.h
+++ b/src/config/config_types.h
@@ -4,8 +4,6 @@
 #include <vector>
 #include <string>
 
-using namespace std;
-
 typedef struct
 {
     std::string ipaddress; // ip address of the Remote Endpoint


### PR DESCRIPTION
# Description

- fixes libuv pipeline buffer issue
- remove `using namespace std;` 

Fixes [#71](https://github.com/ChistaDATA/chista-asabru/issues/71)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

