### PR TITLE
feat: add zk-cluster-monitor-client to docker-compose

### DIFF
--- a/src/load_balancer/LoadBalancer.h
+++ b/src/load_balancer/LoadBalancer.h
@@ -15,6 +15,10 @@ public:
         servers.push_back(server);
     }
 
+    void removeAllServers() {
+        servers.clear();
+    }
+
     T requestServer() {
         return strategy->selectServer(servers);
     }


### PR DESCRIPTION
# Description

- add zk-cluster-monitor-client to docker compose
- listen to zookeeper changes in the monitor
- create ephemeral nodes in zookeeper via the client
- propagate cluster information to the proxy from the zk-monitor

Related :
[#75](https://github.com/ChistaDATA/chista-asabru/issues/75)
[#74](https://github.com/ChistaDATA/chista-asabru/issues/74)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules

