### PR TITLE
fix: unescaped quotes log message

### DIFF
--- a/src/logger/strategy/NetLogStrategy.h
+++ b/src/logger/strategy/NetLogStrategy.h
@@ -2,6 +2,7 @@
 #include "../../Utils.h"
 #include "../content-writer/NetworkContentWriter.h"
 #include "LogStrategy.h"
+#include <regex>
 
 enum LogCode { INFO, ERROR, QUERY, LATENCY };
 
@@ -22,6 +23,9 @@ class NetLogStrategy : public LogStrategy {
 	}
 
 	bool Log(std::string app, std::string key, std::string cause) override {
+		// Escape the double quotes. Otherwise the JSON constructed can be
+		// invalid if double quotes are present in the cause
+		cause = std::regex_replace(cause, std::regex("\""), "\\\"");
 		switch (getLogCode(key)) {
 		case LogCode::QUERY: {
 			return DoLog("{\"type\": \"query\",\"query\":\"" + cause + "\",\"correlation_id\":\"" + app + "\"}\n");


### PR DESCRIPTION
# Description

Since quotes were not escaped, the JSON log generated was invalid when quotes were present in the message.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
